### PR TITLE
Fix SSH agent supervisor wedging on a removed pass-cli subcommand

### DIFF
--- a/fish/completions/docker.fish
+++ b/fish/completions/docker.fish
@@ -1,0 +1,235 @@
+# fish completion for docker                               -*- shell-script -*-
+
+function __docker_debug
+    set -l file "$BASH_COMP_DEBUG_FILE"
+    if test -n "$file"
+        echo "$argv" >> $file
+    end
+end
+
+function __docker_perform_completion
+    __docker_debug "Starting __docker_perform_completion"
+
+    # Extract all args except the last one
+    set -l args (commandline -opc)
+    # Extract the last arg and escape it in case it is a space
+    set -l lastArg (string escape -- (commandline -ct))
+
+    __docker_debug "args: $args"
+    __docker_debug "last arg: $lastArg"
+
+    # Disable ActiveHelp which is not supported for fish shell
+    set -l requestComp "DOCKER_ACTIVE_HELP=0 $args[1] __complete $args[2..-1] $lastArg"
+
+    __docker_debug "Calling $requestComp"
+    set -l results (eval $requestComp 2> /dev/null)
+
+    # Some programs may output extra empty lines after the directive.
+    # Let's ignore them or else it will break completion.
+    # Ref: https://github.com/spf13/cobra/issues/1279
+    for line in $results[-1..1]
+        if test (string trim -- $line) = ""
+            # Found an empty line, remove it
+            set results $results[1..-2]
+        else
+            # Found non-empty line, we have our proper output
+            break
+        end
+    end
+
+    set -l comps $results[1..-2]
+    set -l directiveLine $results[-1]
+
+    # For Fish, when completing a flag with an = (e.g., <program> -n=<TAB>)
+    # completions must be prefixed with the flag
+    set -l flagPrefix (string match -r -- '-.*=' "$lastArg")
+
+    __docker_debug "Comps: $comps"
+    __docker_debug "DirectiveLine: $directiveLine"
+    __docker_debug "flagPrefix: $flagPrefix"
+
+    for comp in $comps
+        printf "%s%s\n" "$flagPrefix" "$comp"
+    end
+
+    printf "%s\n" "$directiveLine"
+end
+
+# this function limits calls to __docker_perform_completion, by caching the result behind $__docker_perform_completion_once_result
+function __docker_perform_completion_once
+    __docker_debug "Starting __docker_perform_completion_once"
+
+    if test -n "$__docker_perform_completion_once_result"
+        __docker_debug "Seems like a valid result already exists, skipping __docker_perform_completion"
+        return 0
+    end
+
+    set --global __docker_perform_completion_once_result (__docker_perform_completion)
+    if test -z "$__docker_perform_completion_once_result"
+        __docker_debug "No completions, probably due to a failure"
+        return 1
+    end
+
+    __docker_debug "Performed completions and set __docker_perform_completion_once_result"
+    return 0
+end
+
+# this function is used to clear the $__docker_perform_completion_once_result variable after completions are run
+function __docker_clear_perform_completion_once_result
+    __docker_debug ""
+    __docker_debug "========= clearing previously set __docker_perform_completion_once_result variable =========="
+    set --erase __docker_perform_completion_once_result
+    __docker_debug "Successfully erased the variable __docker_perform_completion_once_result"
+end
+
+function __docker_requires_order_preservation
+    __docker_debug ""
+    __docker_debug "========= checking if order preservation is required =========="
+
+    __docker_perform_completion_once
+    if test -z "$__docker_perform_completion_once_result"
+        __docker_debug "Error determining if order preservation is required"
+        return 1
+    end
+
+    set -l directive (string sub --start 2 $__docker_perform_completion_once_result[-1])
+    __docker_debug "Directive is: $directive"
+
+    set -l shellCompDirectiveKeepOrder 32
+    set -l keeporder (math (math --scale 0 $directive / $shellCompDirectiveKeepOrder) % 2)
+    __docker_debug "Keeporder is: $keeporder"
+
+    if test $keeporder -ne 0
+        __docker_debug "This does require order preservation"
+        return 0
+    end
+
+    __docker_debug "This doesn't require order preservation"
+    return 1
+end
+
+
+# This function does two things:
+# - Obtain the completions and store them in the global __docker_comp_results
+# - Return false if file completion should be performed
+function __docker_prepare_completions
+    __docker_debug ""
+    __docker_debug "========= starting completion logic =========="
+
+    # Start fresh
+    set --erase __docker_comp_results
+
+    __docker_perform_completion_once
+    __docker_debug "Completion results: $__docker_perform_completion_once_result"
+
+    if test -z "$__docker_perform_completion_once_result"
+        __docker_debug "No completion, probably due to a failure"
+        # Might as well do file completion, in case it helps
+        return 1
+    end
+
+    set -l directive (string sub --start 2 $__docker_perform_completion_once_result[-1])
+    set --global __docker_comp_results $__docker_perform_completion_once_result[1..-2]
+
+    __docker_debug "Completions are: $__docker_comp_results"
+    __docker_debug "Directive is: $directive"
+
+    set -l shellCompDirectiveError 1
+    set -l shellCompDirectiveNoSpace 2
+    set -l shellCompDirectiveNoFileComp 4
+    set -l shellCompDirectiveFilterFileExt 8
+    set -l shellCompDirectiveFilterDirs 16
+
+    if test -z "$directive"
+        set directive 0
+    end
+
+    set -l compErr (math (math --scale 0 $directive / $shellCompDirectiveError) % 2)
+    if test $compErr -eq 1
+        __docker_debug "Received error directive: aborting."
+        # Might as well do file completion, in case it helps
+        return 1
+    end
+
+    set -l filefilter (math (math --scale 0 $directive / $shellCompDirectiveFilterFileExt) % 2)
+    set -l dirfilter (math (math --scale 0 $directive / $shellCompDirectiveFilterDirs) % 2)
+    if test $filefilter -eq 1; or test $dirfilter -eq 1
+        __docker_debug "File extension filtering or directory filtering not supported"
+        # Do full file completion instead
+        return 1
+    end
+
+    set -l nospace (math (math --scale 0 $directive / $shellCompDirectiveNoSpace) % 2)
+    set -l nofiles (math (math --scale 0 $directive / $shellCompDirectiveNoFileComp) % 2)
+
+    __docker_debug "nospace: $nospace, nofiles: $nofiles"
+
+    # If we want to prevent a space, or if file completion is NOT disabled,
+    # we need to count the number of valid completions.
+    # To do so, we will filter on prefix as the completions we have received
+    # may not already be filtered so as to allow fish to match on different
+    # criteria than the prefix.
+    if test $nospace -ne 0; or test $nofiles -eq 0
+        set -l prefix (commandline -t | string escape --style=regex)
+        __docker_debug "prefix: $prefix"
+
+        set -l completions (string match -r -- "^$prefix.*" $__docker_comp_results)
+        set --global __docker_comp_results $completions
+        __docker_debug "Filtered completions are: $__docker_comp_results"
+
+        # Important not to quote the variable for count to work
+        set -l numComps (count $__docker_comp_results)
+        __docker_debug "numComps: $numComps"
+
+        if test $numComps -eq 1; and test $nospace -ne 0
+            # We must first split on \t to get rid of the descriptions to be
+            # able to check what the actual completion will be.
+            # We don't need descriptions anyway since there is only a single
+            # real completion which the shell will expand immediately.
+            set -l split (string split --max 1 \t $__docker_comp_results[1])
+
+            # Fish won't add a space if the completion ends with any
+            # of the following characters: @=/:.,
+            set -l lastChar (string sub -s -1 -- $split)
+            if not string match -r -q "[@=/:.,]" -- "$lastChar"
+                # In other cases, to support the "nospace" directive we trick the shell
+                # by outputting an extra, longer completion.
+                __docker_debug "Adding second completion to perform nospace directive"
+                set --global __docker_comp_results $split[1] $split[1].
+                __docker_debug "Completions are now: $__docker_comp_results"
+            end
+        end
+
+        if test $numComps -eq 0; and test $nofiles -eq 0
+            # To be consistent with bash and zsh, we only trigger file
+            # completion when there are no other completions
+            __docker_debug "Requesting file completion"
+            return 1
+        end
+    end
+
+    return 0
+end
+
+# Since Fish completions are only loaded once the user triggers them, we trigger them ourselves
+# so we can properly delete any completions provided by another script.
+# Only do this if the program can be found, or else fish may print some errors; besides,
+# the existing completions will only be loaded if the program can be found.
+if type -q "docker"
+    # The space after the program name is essential to trigger completion for the program
+    # and not completion of the program name itself.
+    # Also, we use '> /dev/null 2>&1' since '&>' is not supported in older versions of fish.
+    complete --do-complete "docker " > /dev/null 2>&1
+end
+
+# Remove any pre-existing completions for the program since we will be handling all of them.
+complete -c docker -e
+
+# this will get called after the two calls below and clear the $__docker_perform_completion_once_result global
+complete -c docker -n '__docker_clear_perform_completion_once_result'
+# The call to __docker_prepare_completions will setup __docker_comp_results
+# which provides the program's completion choices.
+# If this doesn't require order preservation, we don't use the -k flag
+complete -c docker -n 'not __docker_requires_order_preservation && __docker_prepare_completions' -f -a '$__docker_comp_results'
+# otherwise we use the -k flag
+complete -k -c docker -n '__docker_requires_order_preservation && __docker_prepare_completions' -f -a '$__docker_comp_results'

--- a/fish/conf.d/github-token.fish
+++ b/fish/conf.d/github-token.fish
@@ -1,8 +1,13 @@
-# Set GITHUB_TOKEN from gh CLI on first prompt, if gh is installed and logged in.
-# Silently no-ops when gh is missing or unauthenticated.
+# On first prompt: GITHUB_TOKEN from the gh CLI (for gh itself). Silently
+# no-ops when gh is missing or unauthenticated.
+#
+# GITHUB_PERSONAL_ACCESS_TOKEN (consumed by the GitHub MCP server) is
+# deliberately NOT loaded here -- see the `github-pat` function. Reading it
+# from Proton Pass touches the login keychain, and doing that per shell
+# made macOS prompt for keychain authorization on every new terminal.
 function __mjr_load_github_token --on-event fish_prompt
     functions -e __mjr_load_github_token
     command -q gh; or return
     set -l token (gh auth token 2>/dev/null)
-    test $status -eq 0 -a -n "$token"; and set -gx GITHUB_TOKEN $token
+    test -n "$token"; and set -gx GITHUB_TOKEN $token
 end

--- a/fish/functions/github-pat.fish
+++ b/fish/functions/github-pat.fish
@@ -1,0 +1,24 @@
+# Read the 'github-pat-claude-mcp' item from Proton Pass into this shell.
+#
+# On demand, not on startup: this is a vault-item read, which needs the
+# `ProtonPassCLI` key in the login keychain. Running it from a fish_prompt
+# hook meant macOS asked to authorize keychain access on every new shell.
+#
+# The GitHub MCP server reads GITHUB_PERSONAL_ACCESS_TOKEN from its
+# environment at launch, so run this before starting a session that needs
+# it (or call it from ~/.config/fish/config.local.fish on a machine where
+# you always want it).
+function github-pat --description 'Load GITHUB_PERSONAL_ACCESS_TOKEN from Proton Pass'
+    if not command -q pass-cli
+        echo "github-pat: pass-cli is not installed" >&2
+        return 1
+    end
+    set -l share "AAxj8oq3KJbZiYmPYPQQSILmkQNboq5IK62XMGI8uYVOGKKxibbx0dWyGArzM6fNPqgk9XGgEoYkggOxMa0JlA=="
+    set -l item "NPu8AGXPB9P_aeNO9-gK2ZwQSVsmKnEBPSKcp4Q2Rv4CnQHQw6EM5tcqt-rNWqj-Nl2LdPRvVBgSSB11D3Ugpg=="
+    set -l pat (pass-cli item view --share-id $share --item-id $item --field "API Key" --output human 2>/dev/null)
+    if test -z "$pat"
+        echo "github-pat: could not read the token from Proton Pass" >&2
+        return 1
+    end
+    set -gx GITHUB_PERSONAL_ACCESS_TOKEN $pat
+end

--- a/gitignore_global
+++ b/gitignore_global
@@ -39,3 +39,4 @@ Thumbs.db
 
 *.swp
 *.swo
+**/.claude/settings.local.json

--- a/install.py
+++ b/install.py
@@ -93,8 +93,29 @@ def process_item(source_name, dest, kind, dotfiles_dir, state, args, logger, cou
         counters['errors'] += 1
 
 
+def _chmod_600(path, label, dry_run, logger):
+    """chmod a single file to 600 unless it already is. Returns True if changed."""
+    # is_file() follows symlinks and is True only when the link resolves,
+    # so a broken symlink won't raise FileNotFoundError here.
+    if not path.is_file():
+        return False
+
+    perms = oct(os.stat(path).st_mode)[-3:]
+    if perms == '600':
+        return False
+
+    logger.debug(f"Fixing {label} permissions: {perms} -> 600")
+    if not dry_run:
+        os.chmod(path, 0o600)
+    logger.success(f"Set {label} permissions to 600", indent=True)
+    return True
+
+
 def fix_ssh_permissions(ssh_dir, dry_run, logger):
-    """Ensure ~/.ssh is 700 and ~/.ssh/config is 600. No-op when already correct."""
+    """Ensure ~/.ssh is 700, and config plus any private key is 600.
+
+    No-op for anything already correct.
+    """
     if not ssh_dir.exists():
         return
 
@@ -105,16 +126,15 @@ def fix_ssh_permissions(ssh_dir, dry_run, logger):
             os.chmod(ssh_dir, 0o700)
         logger.success("Set ~/.ssh directory permissions to 700", indent=True)
 
-    ssh_config = ssh_dir / 'config'
-    # is_file() follows symlinks and is True only when the link resolves,
-    # so a broken ~/.ssh/config symlink won't raise FileNotFoundError here.
-    if ssh_config.is_file():
-        config_perms = oct(os.stat(ssh_config).st_mode)[-3:]
-        if config_perms != '600':
-            logger.debug(f"Fixing ~/.ssh/config permissions: {config_perms} -> 600")
-            if not dry_run:
-                os.chmod(ssh_config, 0o600)
-            logger.success("Set ~/.ssh/config permissions to 600", indent=True)
+    _chmod_600(ssh_dir / 'config', '~/.ssh/config', dry_run, logger)
+
+    # Private keys: id_* without a .pub suffix. ssh refuses a key that is
+    # group- or world-readable, and the executable bit some of these have
+    # picked up over the years is just noise.
+    for key in sorted(ssh_dir.glob('id_*')):
+        if key.suffix == '.pub':
+            continue
+        _chmod_600(key, f"~/.ssh/{key.name}", dry_run, logger)
 
 
 def generate_zellij_config(zellij_config_dir, dry_run, logger):

--- a/launchd/proton-pass-ssh-agent.sh
+++ b/launchd/proton-pass-ssh-agent.sh
@@ -3,7 +3,7 @@
 # guarantees keys are actually loaded before declaring success.
 #
 # pass-cli has two failure modes that bare KeepAlive doesn't catch:
-#   1. The vault/items endpoint can flake at boot while `pass-cli test`
+#   1. The vault/items endpoint can flake at boot while the session probe
 #      already succeeds -- pass-cli will then "start successfully" with
 #      zero keys loaded, and stay that way until manually restarted.
 #   2. A transient error on the long-poll events stream causes pass-cli
@@ -16,12 +16,29 @@
 # returns when the agent has been observed serving >=1 key, and waits on
 # the agent forever after; if pass-cli ever exits, the outer loop kicks
 # in again.
+#
+# The reachability probe is an OPTIMISATION, never a gate. pass-cli's CLI
+# surface moves under us: 2.2.4 (2026-07-31) removed the `test`
+# subcommand this script used to probe with, and because a failed probe
+# blocked the start, the agent silently never came up for four weeks. Any
+# probe failure that looks like a CLI-surface change now fails OPEN and
+# we attempt a start anyway. start_and_supervise's "socket serves >=1
+# key" check is the real health check, and it depends on no other
+# subcommand.
 
 set -u
 
 PASS_CLI=/opt/homebrew/bin/pass-cli
 SSH_ADD=/usr/bin/ssh-add
 SOCKET_PATH="$HOME/.ssh/proton-pass-agent.sock"
+PID_FILE="$HOME/.ssh/proton-pass-agent.pid"
+LOG_FILE="$HOME/Library/Logs/proton-pass-ssh-agent.log"
+
+# Subcommand used to probe session + connectivity. Deliberately one that
+# does NOT touch the macOS keyring: vault and item reads need the
+# `ProtonPassCLI` keychain key and would pop an authorization dialog from
+# a background agent. `info` reads session state only.
+PROBE_CMD=info
 
 INITIAL_BACKOFF=5
 MAX_BACKOFF=60
@@ -31,19 +48,94 @@ MAX_BACKOFF=60
 # kill it -- otherwise we kill pass-cli just as its own retry is about
 # to succeed, and the outer loop hot-loops against a recovering API.
 KEY_LOAD_TIMEOUT=90
+# A stuck probe used to write one line per minute forever (22k lines,
+# 1.5MB). Log the first failure of a streak with its actual error text,
+# then only every Nth repeat.
+WAIT_LOG_EVERY=10
+MAX_LOG_BYTES=$((5 * 1024 * 1024))
 
 log() {
     printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*"
 }
 
-network_ok() {
-    "$PASS_CLI" test >/dev/null 2>&1
+# Truncate the log in place once it gets large, keeping one generation.
+# Must be copy-then-truncate, never mv: launchd holds our stdout open on
+# this inode, so a renamed file would keep receiving every line we log.
+rotate_log() {
+    [ -f "$LOG_FILE" ] || return 0
+    local size
+    size=$(stat -f %z "$LOG_FILE" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$MAX_LOG_BYTES" ]; then
+        cp -f "$LOG_FILE" "$LOG_FILE.1" 2>/dev/null || true
+        : > "$LOG_FILE" 2>/dev/null || true
+        log "rotated log at ${size} bytes (previous generation: $LOG_FILE.1)"
+    fi
+    return 0
+}
+
+preflight() {
+    if [ ! -x "$PASS_CLI" ]; then
+        log "ERROR: $PASS_CLI missing or not executable -- the agent cannot start until it is reinstalled (brew install protonpass/tap/pass-cli)"
+        return 0
+    fi
+    log "pass-cli: $("$PASS_CLI" --version 2>&1 | head -1)"
+    if "$PASS_CLI" "$PROBE_CMD" >/dev/null 2>&1; then
+        log "probe '$PASS_CLI $PROBE_CMD' OK"
+    else
+        log "probe '$PASS_CLI $PROBE_CMD' non-zero at startup (see first waiting line for the reason)"
+    fi
+    return 0
+}
+
+# Set by probe_ok to the probe's output, for the caller to log.
+PROBE_ERR=""
+# Count of consecutive fail-open probes, for rate-limiting that log line.
+PROBE_UNSUPPORTED=0
+
+# Returns 0 when we should go ahead and (re)start the agent: either the
+# probe succeeded, or the probe itself is unusable -- an unrecognised
+# subcommand or a missing binary -- in which case we fail open rather
+# than block the agent forever behind a broken check.
+probe_ok() {
+    local out rc
+    out=$("$PASS_CLI" "$PROBE_CMD" 2>&1)
+    rc=$?
+    PROBE_ERR=$(printf '%s' "$out" | tr '\n' ' ' | cut -c1-200)
+    [ "$rc" -eq 0 ] && return 0
+    if [ "$rc" -eq 127 ] || printf '%s' "$out" | grep -qE 'unrecognized subcommand|unexpected argument'; then
+        PROBE_UNSUPPORTED=$((PROBE_UNSUPPORTED + 1))
+        if [ "$PROBE_UNSUPPORTED" -eq 1 ] || [ $((PROBE_UNSUPPORTED % WAIT_LOG_EVERY)) -eq 0 ]; then
+            log "PROBE UNSUPPORTED ($("$PASS_CLI" --version 2>&1 | head -1)): ${PROBE_ERR:-exit $rc} -- failing open, starting the agent anyway"
+        fi
+        return 0
+    fi
+    return 1
+}
+
+# Kill any pass-cli agent bound to our socket that we did not start. A
+# hand-run `pass-cli ssh-agent daemon start` leaves an orphan (ppid 1)
+# holding the socket; starting a second agent on top of it leaves two
+# processes fighting over one socket file, which surfaces as
+# "Connection refused" from ssh-add. The supervisor is authoritative.
+reap_orphan_agents() {
+    local pids pid
+    pids=$(pgrep -f "ssh-agent start --socket-path $SOCKET_PATH" 2>/dev/null)
+    for pid in $pids; do
+        log "reaping orphan pass-cli agent pid=$pid"
+        kill "$pid" 2>/dev/null || true
+    done
+    if [ -n "$pids" ]; then
+        sleep 1
+    fi
+    rm -f "$PID_FILE"
+    return 0
 }
 
 # Start pass-cli in the background, wait for it to bind the socket and
 # load >=1 key, then wait on it forever. Returns non-zero if the agent
 # never reached a healthy state or exited later.
 start_and_supervise() {
+    reap_orphan_agents
     [ -e "$SOCKET_PATH" ] && rm -f "$SOCKET_PATH"
 
     log "starting pass-cli ssh-agent"
@@ -81,10 +173,17 @@ start_and_supervise() {
 
 trap 'log "received signal; exiting"; exit 0' INT TERM
 
+rotate_log
+preflight
+
 backoff=$INITIAL_BACKOFF
+probe_failures=0
 while true; do
-    until network_ok; do
-        log "waiting for Proton Pass connectivity (next probe in ${backoff}s)"
+    until probe_ok; do
+        probe_failures=$((probe_failures + 1))
+        if [ "$probe_failures" -eq 1 ] || [ $((probe_failures % WAIT_LOG_EVERY)) -eq 0 ]; then
+            log "waiting for Proton Pass connectivity (probe #${probe_failures} failed: ${PROBE_ERR:-no output}; next probe in ${backoff}s)"
+        fi
         t_before=$(date +%s)
         sleep "$backoff"
         elapsed=$(($(date +%s) - t_before))
@@ -102,6 +201,10 @@ while true; do
         fi
     done
 
+    if [ "$probe_failures" -gt 0 ]; then
+        log "Proton Pass reachable again after ${probe_failures} failed probe(s)"
+        probe_failures=0
+    fi
     log "Proton Pass reachable; bringing up agent"
 
     # Only reset backoff when the agent actually reached a healthy state.

--- a/ssh/config
+++ b/ssh/config
@@ -7,6 +7,10 @@ Host *
     AddKeysToAgent yes
     UseKeychain yes
     IdentityFile ~/.ssh/id_ed25519
+    # Offer only the key above. Without this ssh also offers every default
+    # identity, including the stale ~/.ssh/id_rsa from 2017. Safe with the
+    # agent: Proton serves this same key, so its public half is listed here.
+    IdentitiesOnly yes
 
 Host mjrnas.tail1737c.ts.net
     HostName mjrnas.tail1737c.ts.net

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -414,6 +414,38 @@ class TestFixSSHPermissions(unittest.TestCase):
             Path(self.test_dir) / "no-ssh", dry_run=False, logger=self.logger
         )
 
+    def test_private_keys_fixed_to_600(self):
+        for name, mode in (("id_ed25519", 0o700), ("id_rsa", 0o644)):
+            (self.ssh_dir / name).write_text("PRIVATE KEY\n")
+            os.chmod(str(self.ssh_dir / name), mode)
+
+        install.fix_ssh_permissions(self.ssh_dir, dry_run=False, logger=self.logger)
+
+        self.assertEqual(self._perms(self.ssh_dir / "id_ed25519"), '600')
+        self.assertEqual(self._perms(self.ssh_dir / "id_rsa"), '600')
+
+    def test_public_keys_and_unrelated_files_untouched(self):
+        pub = self.ssh_dir / "id_ed25519.pub"
+        pub.write_text("ssh-ed25519 AAAA...\n")
+        os.chmod(str(pub), 0o644)
+        known = self.ssh_dir / "known_hosts"
+        known.write_text("github.com ssh-ed25519 AAAA...\n")
+        os.chmod(str(known), 0o644)
+
+        install.fix_ssh_permissions(self.ssh_dir, dry_run=False, logger=self.logger)
+
+        self.assertEqual(self._perms(pub), '644')
+        self.assertEqual(self._perms(known), '644')
+
+    def test_private_key_dry_run_does_not_change_perms(self):
+        key = self.ssh_dir / "id_ed25519"
+        key.write_text("PRIVATE KEY\n")
+        os.chmod(str(key), 0o700)
+
+        install.fix_ssh_permissions(self.ssh_dir, dry_run=True, logger=self.logger)
+
+        self.assertEqual(self._perms(key), '700')
+
 
 class TestProcessItem(DotfilesTestCase):
     """Exercise the real install.process_item on a sandboxed filesystem."""


### PR DESCRIPTION
## Why

The launchd supervisor gated every agent start on `pass-cli test`. That subcommand was removed in **pass-cli 2.2.4** (tap release 2026-07-31 — the day after the last successful start):

```
$ pass-cli test; echo $?
error: unrecognized subcommand 'test'
2
```

The probe discarded stderr and a failed probe blocked the start forever, so the agent had not auto-started in four weeks — 6,493 consecutive `waiting for Proton Pass connectivity` lines and no error anywhere. The symptom that surfaced was keychain password prompts, which turned out to have a second, independent cause (below).

## What changed

**The probe is an optimisation, not a gate** (`launchd/proton-pass-ssh-agent.sh`):

- probe with `pass-cli info`, chosen because it does not touch the macOS keyring the way vault/item reads do
- **fail open** on a CLI-surface error (`unrecognized subcommand`, exit 127): log it loudly and start the agent anyway. `start_and_supervise`'s "socket serves ≥1 key" check is the real health check and depends on no other subcommand
- log the probe's actual error on the first failure of a streak, then every 10th, instead of one bare line per minute forever
- preflight the binary and probe at startup; rotate the log at 5 MB by copy-then-truncate — never `mv`, which would leave launchd's stdout fd pointing at the rotated file
- reap orphan agents bound to our socket before binding, so a hand-run `pass-cli ssh-agent daemon start` can no longer fight the supervisor for it

`KEY_LOAD_TIMEOUT=90` and the backoff-reset guard are unchanged.

**The keychain prompts.** Reading the GitHub PAT from Proton Pass is an *item* read, which needs the `ProtonPassCLI` login-keychain key — and it ran from a `fish_prompt` hook, so macOS asked to authorize keychain access on every new shell. Moved to an on-demand `github-pat` function; only `gh auth token` stays on the hook. (The keychain item's ACL is invalidated by every Homebrew upgrade, since the Cellar path is versioned — hence the recurrence.)

**Smaller items.** `IdentitiesOnly yes` in `ssh/config` (ssh was offering the stale 2017 `id_rsa` to every host), and `fix_ssh_permissions` now chmods private keys to 600.

## Verification

- Fail-open and wait-with-reason exercised against stub CLIs in a sandbox; rotation confirmed to keep the inode so launchd's fd stays valid
- The new supervisor reaped the hand-started orphan and brought the agent up: `agent ready: 1 key(s) loaded`, correctly parented, `ssh-add -l` shows the key
- Auth works through the agent **and** through the `IdentityAgent=none` fallback
- A clean-env shell sets `GITHUB_TOKEN` and no longer touches the vault
- `python3 -m unittest discover tests` — 82 pass (3 new)

## Note for the reviewer

Two follow-ups need a click and are not in this PR: run `github-pat` once and answer the keychain dialog with **Always Allow**, and optionally `brew pin pass-cli` to stop the weekly upgrade churn that re-invalidates that ACL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTPqk33jgv3YkHAUMy3AB1